### PR TITLE
Reduce waittime on nodeSetup.json configuration

### DIFF
--- a/scripts/generate_configs.py
+++ b/scripts/generate_configs.py
@@ -30,8 +30,8 @@ def generate_genesis(wallets,klv_supply,path):
 
 def generate_nodes_setup(wallets, validators, path):
     start_time = int(datetime.now().timestamp())
-    start_time = int(start_time) + 500 - (int(start_time) % 500)
-    chain_id = start_time // 500
+    start_time = int(start_time) + 75 - (int(start_time) % 75)
+    chain_id = start_time // 75
     
     slot_per_epoch = 20
     


### PR DESCRIPTION
This pull request updates the logic for generating node setup configuration in `scripts/generate_configs.py`. The main change is a reduction in the slot interval used for calculating the blockchain's start time and chain ID, which will result in more frequent chain intervals.

Configuration logic update:

* Changed the slot interval from 500 to 75 in the calculation of `start_time` and `chain_id` in the `generate_nodes_setup` function, making chain intervals more frequent.