### PR TITLE
QOL improvements for localnet use (local image checks, image and no-restart flags)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ coverage.html
 *.test
 *.out
 vendor/
+
+**/node_modules

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -23,6 +23,8 @@ type configFlags struct {
 	ConsensusGroupSize int
 	StartTime          int64
 	MinNodes           int
+	Image              string
+	NoRestart          bool
 }
 
 func newConfigCommand(app *AppContext) *cobra.Command {
@@ -51,6 +53,8 @@ func bindConfigFlags(cmd *cobra.Command, cf *configFlags) {
 	cmd.Flags().IntVar(&cf.ConsensusGroupSize, "consensus-group-size", 0, "consensus group size (default: validators)")
 	cmd.Flags().Int64Var(&cf.StartTime, "start-time", 0, "unix seconds; rounded up to next 75s boundary")
 	cmd.Flags().IntVar(&cf.MinNodes, "min-nodes", 0, "minimum nodes for block production")
+	cmd.Flags().StringVar(&cf.Image, "image", "", "klever-go docker image to use (default: "+domain.KleverImage+")")
+	cmd.Flags().BoolVar(&cf.NoRestart, "no-restart", false, "omit restart: unless-stopped from generated services")
 }
 
 func runConfigGenerate(cmd *cobra.Command, app *AppContext, cf *configFlags) error {
@@ -59,7 +63,7 @@ func runConfigGenerate(cmd *cobra.Command, app *AppContext, cf *configFlags) err
 		return err
 	}
 
-	g := keys.NewGenerator(dockercli.NewExecRunner(), st.KleverImage)
+	g := keys.NewGenerator(dockercli.NewExecRunner(), domain.KleverImage)
 	kr, err := g.Generate(cmd.Context(), st, app.KeysDir(), false)
 	if err != nil {
 		return err
@@ -126,6 +130,9 @@ func resolveStateForConfig(app *AppContext, cf *configFlags) (domain.LocalnetSta
 	if cf.StartTime > 0 {
 		st.StartTime = cf.StartTime
 	}
+	if cf.Image != "" {
+		st.KleverImage = cf.Image
+	}
 	if st.KleverImage == "" {
 		st.KleverImage = domain.KleverImage
 	}
@@ -135,7 +142,7 @@ func resolveStateForConfig(app *AppContext, cf *configFlags) (domain.LocalnetSta
 	return st, nil
 }
 
-func runComposeGenerate(app *AppContext) error {
+func runComposeGenerate(app *AppContext, noRestart bool) error {
 	if !state.Exists(app.StateFilePath()) {
 		return fmt.Errorf("state file not found; run `localnet config generate` first")
 	}
@@ -152,7 +159,9 @@ func runComposeGenerate(app *AppContext) error {
 	if err != nil {
 		return err
 	}
-	out, err := compose.Build(st, services, compose.DefaultResources())
+	res := compose.DefaultResources()
+	res.Restart = !noRestart
+	out, err := compose.Build(st, services, res)
 	if err != nil {
 		return err
 	}
@@ -164,13 +173,15 @@ func runComposeGenerate(app *AppContext) error {
 }
 
 func newComposeCommand(app *AppContext) *cobra.Command {
+	var noRestart bool
 	generate := &cobra.Command{
 		Use:   "generate",
 		Short: "Generate docker-compose.yaml",
 		RunE: func(_ *cobra.Command, _ []string) error {
-			return runComposeGenerate(app)
+			return runComposeGenerate(app, noRestart)
 		},
 	}
+	generate.Flags().BoolVar(&noRestart, "no-restart", false, "omit restart: unless-stopped from generated services")
 	wrapper := &cobra.Command{
 		Use:   "compose",
 		Short: "Docker Compose file generation",

--- a/internal/cli/keys.go
+++ b/internal/cli/keys.go
@@ -45,7 +45,7 @@ func runKeysGenerate(cmd *cobra.Command, app *AppContext, validators int, force 
 		return ensureErr
 	}
 
-	g := keys.NewGenerator(dockercli.NewExecRunner(), st.KleverImage)
+	g := keys.NewGenerator(dockercli.NewExecRunner(), domain.KleverImage)
 	res, err := g.Generate(cmd.Context(), st, app.KeysDir(), force)
 	if err != nil {
 		return err

--- a/internal/cli/lifecycle.go
+++ b/internal/cli/lifecycle.go
@@ -51,9 +51,14 @@ func isFreshGenesis(app *AppContext) bool {
 }
 
 func prepareFreshStart(cmd *cobra.Command, app *AppContext) error {
-	app.Printer.Info("Pulling validator image (warming cache before genesis stamp)")
-	if _, err := app.Docker.ComposePull(cmd.Context()); err != nil {
-		return err
+	st, err := state.Load(app.StateFilePath())
+	if err == nil && app.Docker.ImageExists(cmd.Context(), st.KleverImage) {
+		app.Printer.Info("Validator image %s already present locally, skipping pull", st.KleverImage)
+	} else {
+		app.Printer.Info("Pulling validator image (warming cache before genesis stamp)")
+		if _, err := app.Docker.ComposePull(cmd.Context()); err != nil {
+			return err
+		}
 	}
 
 	nodesSetupPath := filepath.Join(app.NodeCfgDir(), "nodesSetup.json")
@@ -71,11 +76,7 @@ func prepareFreshStart(cmd *cobra.Command, app *AppContext) error {
 		return err
 	}
 
-	if state.Exists(app.StateFilePath()) {
-		st, err := state.Load(app.StateFilePath())
-		if err != nil {
-			return err
-		}
+	if err == nil {
 		st.StartTime = newStart
 		if err := state.Save(app.StateFilePath(), st); err != nil {
 			return err

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -47,7 +47,7 @@ func runSetupAll(cmd *cobra.Command, app *AppContext, cf *configFlags) error {
 	if err := runConfigGenerate(cmd, app, cf); err != nil {
 		return err
 	}
-	if err := runComposeGenerate(app); err != nil {
+	if err := runComposeGenerate(app, cf.NoRestart); err != nil {
 		return err
 	}
 	printNextSteps(app)

--- a/internal/compose/builder.go
+++ b/internal/compose/builder.go
@@ -23,6 +23,7 @@ type Resources struct {
 	CPUs       string
 	LogMaxSize string
 	LogMaxFile string
+	Restart    bool
 }
 
 func DefaultResources() Resources {
@@ -31,11 +32,13 @@ func DefaultResources() Resources {
 		CPUs:       "1.0",
 		LogMaxSize: "50m",
 		LogMaxFile: "5",
+		Restart:    true,
 	}
 }
 
 type templateData struct {
 	Image            string
+	SeednodeImage    string
 	NetworkName      string
 	NetworkSubnet    string
 	SeednodeIP       string
@@ -44,6 +47,7 @@ type templateData struct {
 	CPUs             string
 	LogMaxSize       string
 	LogMaxFile       string
+	Restart          bool
 	Validators       []ValidatorService
 }
 
@@ -66,6 +70,7 @@ func Build(state domain.LocalnetState, services []ValidatorService, res Resource
 
 	data := templateData{
 		Image:            state.KleverImage,
+		SeednodeImage:    domain.KleverImage,
 		NetworkName:      domain.NetworkName,
 		NetworkSubnet:    domain.NetworkSubnet,
 		SeednodeIP:       domain.SeednodeStaticIP,
@@ -74,6 +79,7 @@ func Build(state domain.LocalnetState, services []ValidatorService, res Resource
 		CPUs:             res.CPUs,
 		LogMaxSize:       res.LogMaxSize,
 		LogMaxFile:       res.LogMaxFile,
+		Restart:          res.Restart,
 		Validators:       ordered,
 	}
 

--- a/internal/compose/templates/docker-compose.yaml.tmpl
+++ b/internal/compose/templates/docker-compose.yaml.tmpl
@@ -1,8 +1,10 @@
 services:
   seednode:
-    image: {{ .Image }}
+    image: {{ .SeednodeImage }}
     container_name: seednode
+{{- if .Restart }}
     restart: unless-stopped
+{{- end }}
     volumes:
       - ./config/seednode:/opt/klever-blockchain/config/seednode
     entrypoint: /usr/local/bin/seednode
@@ -23,7 +25,9 @@ services:
   node{{ .Index }}:
     image: {{ $.Image }}
     container_name: node{{ .Index }}
+{{- if $.Restart }}
     restart: unless-stopped
+{{- end }}
     depends_on:
       - seednode
     networks:

--- a/internal/dockercli/client.go
+++ b/internal/dockercli/client.go
@@ -106,6 +106,11 @@ func (c *Client) ComposeVersion(ctx context.Context) (ComposeInfo, error) {
 	return ComposeInfo{Raw: strings.TrimSpace(out), Major: maj, Minor: mnr, Patch: pat}, nil
 }
 
+func (c *Client) ImageExists(ctx context.Context, image string) bool {
+	_, err := c.run(ctx, []string{"image", "inspect", image}, io.Discard, io.Discard)
+	return err == nil
+}
+
 func (c *Client) Run(ctx context.Context, args []string) (RunResult, error) {
 	res, err := c.run(ctx, args, nil, nil)
 	if err != nil {

--- a/readme.md
+++ b/readme.md
@@ -71,3 +71,12 @@ Run `localnet --help` for the full tree. Key commands:
 - `localnet monitor` — open the live TUI dashboard directly.
 - `localnet doctor` — verify Docker + disk + group membership.
 - `localnet clean` / `clean-all` — remove generated artifacts (`clean-all` also wipes keys/dbs/logs and prompts for confirmation).
+
+### Flags
+
+`run`, `setup-all`, `config generate`, and `compose generate` accept:
+
+- `--image <ref>` — docker image for the **validator** node containers (default: the version pinned in this build). The seednode and key-generation containers always use the default pinned image, since custom/slim builds may not include the `seednode` and `keygenerator` binaries.
+- `--no-restart` — omit `restart: unless-stopped` from generated `docker-compose.yaml` services.
+
+Other config flags: `-n/--validators`, `-s/--max-supply`, `--consensus-group-size`, `--start-time`, `--min-nodes`. See `localnet setup-all --help` for details.


### PR DESCRIPTION
- Updated configFlags to include Image and NoRestart fields
- Enhanced runComposeGenerate to respect the no-restart flag
- Modified lifecycle to check for existing images before pulling
- Updated Docker Compose template to conditionally set restart policy
- Added ImageExists method to Docker client for image existence checks